### PR TITLE
File upload by drag drop

### DIFF
--- a/src/main/java/com/tidal/wave/command/Commands.java
+++ b/src/main/java/com/tidal/wave/command/Commands.java
@@ -60,7 +60,8 @@ public class Commands {
         SET_INNER_HTML("setInnerHtmlAction"),
         SET_TEXT("setTextAction"),
         SET_VALUE("setValueAction"),
-        UPLOAD_FILE("fileUploadAction");
+        UPLOAD_FILE("fileUploadAction"),
+        UPLOAD_FILE_DRAG_AND_DROP("fileUploadByDragAndDropAction");
 
         private final String command;
 

--- a/src/main/java/com/tidal/wave/commands/FileUploadByDragAndDrop.java
+++ b/src/main/java/com/tidal/wave/commands/FileUploadByDragAndDrop.java
@@ -60,10 +60,9 @@ public class FileUploadByDragAndDrop extends CommandAction implements Command<Vo
 
     @Override
     protected Map<Class<? extends Throwable>, Supplier<String>> ignoredEx() {
-        return CommandExceptions.Of.sendKeys();
+        return CommandExceptions.TypeOf.stale();
     }
     public void fileUploadByDragAndDropAction() {
-
         function.apply(context);
     }
 

--- a/src/main/java/com/tidal/wave/commands/FileUploadByDragAndDrop.java
+++ b/src/main/java/com/tidal/wave/commands/FileUploadByDragAndDrop.java
@@ -1,0 +1,74 @@
+package com.tidal.wave.commands;
+
+import com.tidal.utils.counter.TimeCounter;
+import com.tidal.utils.filehandlers.Finder;
+import com.tidal.wave.command.Command;
+import com.tidal.wave.command.CommandAction;
+import com.tidal.wave.command.CommandContext;
+import com.tidal.wave.command.Commands;
+import com.tidal.wave.exceptions.CommandExceptions;
+import com.tidal.wave.exceptions.NoSuchFileException;
+import com.tidal.wave.javascript.Scripts;
+import com.tidal.wave.supplier.ObjectSupplier;
+import com.tidal.wave.webelement.Element;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebElement;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class FileUploadByDragAndDrop extends CommandAction implements Command<Void> {
+
+
+    private final Supplier<Map<Class<? extends Throwable>, Supplier<String>>> ignoredExceptions = this::ignoredEx;
+    private final Element webElement = (Element) ObjectSupplier.instanceOf(Element.class);
+    private final TimeCounter timeCounter = new TimeCounter();
+    private String fileName;
+
+    @Override
+    public void contextSetter(CommandContext context) {
+        this.context = context;
+        this.fileName = context.getTextInput();
+    }
+
+    @Override
+    public CommandContext getCommandContext() {
+        return context;
+    }
+
+    Function<CommandContext, Void> function = e -> {
+        if (fileName.isEmpty()) throw new IllegalArgumentException("File name should not be null or empty");
+
+        String filePath;
+        if (Finder.findFileIfExists(fileName).isPresent()) {
+            filePath = Finder.findFilePath(fileName);
+        } else {
+            throw new NoSuchFileException(String.format("No file could be found with the given file name '%s'", fileName));
+        }
+        WebElement element = webElement.getElement(context);
+        WebElement virtualElement=(WebElement)((JavascriptExecutor)((RemoteWebElement)(element)).getWrappedDriver()).executeScript(Scripts.dragAndDropFileUpload(),element);
+        virtualElement.sendKeys(filePath);
+        return null;
+    };
+
+    @Override
+    public Function<CommandContext, Void> getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Map<Class<? extends Throwable>, Supplier<String>> ignoredEx() {
+        return CommandExceptions.Of.sendKeys();
+    }
+    public void fileUploadByDragAndDropAction() {
+
+        function.apply(context);
+    }
+
+    public void fileUploadByDragAndDrop() {
+        timeCounter.restart();
+        super.execute(Commands.InputCommands.UPLOAD_FILE_DRAG_AND_DROP.toString(), ignoredExceptions, timeCounter);
+    }
+}

--- a/src/main/java/com/tidal/wave/javascript/Scripts.java
+++ b/src/main/java/com/tidal/wave/javascript/Scripts.java
@@ -48,4 +48,34 @@ public class Scripts {
                 "// Example usage: find an element with the id \"my-element\" inside a shadow DOM\n" +
                 "let element = findElementById('my-element', document);\n";
     }
+
+
+    public static String dragAndDropFileUpload(){
+        return "var target = arguments[0]," +
+                "    offsetX = 0," +
+                "    offsetY = 0," +
+                "    document = target.ownerDocument || document," +
+                "    window = document.defaultView || window;" +
+                "" +
+                "var input = document.createElement('INPUT');" +
+                "input.type = 'file';" +
+                "input.style.display = 'none';" +
+                "input.onchange = function () {" +
+                "  var rect = target.getBoundingClientRect()," +
+                "      x = rect.left + (offsetX || (rect.width >> 1))," +
+                "      y = rect.top + (offsetY || (rect.height >> 1))," +
+                "      dataTransfer = { files: this.files };" +
+                "" +
+                "  ['dragenter', 'dragover', 'drop'].forEach(function (name) {" +
+                "    var evt = document.createEvent('MouseEvent');" +
+                "    evt.initMouseEvent(name, !0, !0, window, 0, 0, 0, x, y, !1, !1, !1, !1, 0, null);" +
+                "    evt.dataTransfer = dataTransfer;" +
+                "    target.dispatchEvent(evt);" +
+                "  });" +
+                "" +
+                "  setTimeout(function () { document.body.removeChild(input); }, 25);" +
+                "};" +
+                "document.body.appendChild(input);" +
+                "return input;";
+    }
 }

--- a/src/main/java/com/tidal/wave/webelement/UIActions.java
+++ b/src/main/java/com/tidal/wave/webelement/UIActions.java
@@ -770,6 +770,20 @@ public class UIActions implements UIElement {
     }
 
     /**
+     * Method to upload a file to the application via drag and drop
+     * This method is aimed at pages where files are uploaded when file is dropped into the drag and drop control
+     * component and there is no upload button
+     *
+     * If only a file name is provided, the file should exist in the 'resources' folder of the project
+     *
+     * @param fileName of the file to be found - An absolute, relative path or file name can be provided.
+     */
+    public void uploadFileByDragAndDrop(@NotNull String fileName) {
+        executor.debugMode(debugMode).usingLocator(locators).withText(fileName).invokeCommand(FileUploadByDragAndDrop.class);
+    }
+
+
+    /**
      * <p>Just the plain old Thread.sleep wrapped in a method with a nicer name. </p>
      * <p>Use it when absolutely necessary as this is a static wait and would slow down the tests.</p>
      * <b>Examples:</b> <br/>

--- a/src/main/java/com/tidal/wave/webelement/UIActions.java
+++ b/src/main/java/com/tidal/wave/webelement/UIActions.java
@@ -771,7 +771,7 @@ public class UIActions implements UIElement {
 
     /**
      * Method to upload a file to the application via drag and drop
-     * This method is aimed at pages where files are uploaded when file is dropped into the drag and drop control
+     * This method is to be used in pages where files are uploaded when file is dropped into the drag and drop control
      * component and there is no upload button
      *
      * If only a file name is provided, the file should exist in the 'resources' folder of the project

--- a/src/main/java/com/tidal/wave/webelement/UIElement.java
+++ b/src/main/java/com/tidal/wave/webelement/UIElement.java
@@ -142,6 +142,8 @@ public interface UIElement {
 
     void uploadFileWRC(String fileName);
 
+    void uploadFileByDragAndDrop(String fileName);
+
     UIElement pause(int seconds);
 
 

--- a/src/test/java/com/tidal/wave/commands/FileUploadTest.java
+++ b/src/test/java/com/tidal/wave/commands/FileUploadTest.java
@@ -1,0 +1,38 @@
+package com.tidal.wave.commands;
+
+import com.tidal.utils.filehandlers.Finder;
+import com.tidal.wave.browser.Browser;
+import org.junit.*;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import java.io.File;
+
+import static com.tidal.wave.browser.Browser.close;
+import static com.tidal.wave.page.Page.dismissAlert;
+import static com.tidal.wave.page.Page.getAlertText;
+import static com.tidal.wave.webelement.ElementFinder.find;
+
+public class FileUploadTest {
+
+    @Before
+    public void initialize() {
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--headless");
+        options.addArguments("--remote-allow-origins=*");
+
+        Browser.withOptions(options).open("file://" + Finder.findFilePath("components"+ File.separator+"fileUpload"+File.separator+"fileUpload.html"));
+    }
+
+    @After
+    public void testCleanup() {
+        close();
+    }
+    @Test
+    public void fileUploadDragAndDropTest() {
+        String fileName="TestCSVFile.csv";
+        find("id:dropzone").uploadFileByDragAndDrop(fileName);
+        String alertText = getAlertText();
+        Assert.assertTrue("File upload failed, Alert do not contain the file name "+fileName+" alert text "+alertText, alertText.contains(fileName));
+        dismissAlert();
+    }
+}

--- a/src/test/java/com/tidal/wave/commands/FileUploadTest.java
+++ b/src/test/java/com/tidal/wave/commands/FileUploadTest.java
@@ -19,7 +19,6 @@ public class FileUploadTest {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless");
         options.addArguments("--remote-allow-origins=*");
-
         Browser.withOptions(options).open("file://" + Finder.findFilePath("components"+ File.separator+"fileUpload"+File.separator+"fileUpload.html"));
     }
 

--- a/src/test/resources/components/fileUpload/fileUpload.html
+++ b/src/test/resources/components/fileUpload/fileUpload.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Drag and drop file upload</title>
+    <style>
+    #dropzone {
+      border: 2px dashed #ccc;
+      padding: 20px;
+      font-size: 1.2em;
+      text-align: center;
+      width: 400px;
+      height: 200px;
+    }
+  </style>
+</head>
+<body>
+<div id="dropzone">Drag and drop your file here</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var dropzone = document.getElementById('dropzone');
+
+      dropzone.ondragover = function() {
+        this.classList.add('dragover');
+        return false;
+      }
+
+      dropzone.ondragleave = function() {
+        this.classList.remove('dragover');
+        return false;
+      }
+
+      dropzone.ondrop = function(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.classList.remove('dragover');
+
+        var fileName = event.dataTransfer.files[0].name;
+        displayFileName(fileName);
+      }
+
+      function displayFileName(fileName) {
+        alert('File "' + fileName + '" selected');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Added support for file upload by drag and drop. This method can be used to upload files in webpages where there is a drag and drop control and no upload button for file upload.