### PR TITLE
hotfix: get dom attribute/property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.tidalcode</groupId>
     <artifactId>wave</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
 
     <name>Tidal Automation Library</name>
     <description>Automation Code Repository</description>

--- a/src/main/java/dev/tidalcode/wave/commands/FindAllTextData.java
+++ b/src/main/java/dev/tidalcode/wave/commands/FindAllTextData.java
@@ -50,7 +50,17 @@ public final class FindAllTextData extends CommandAction implements Command<List
         if (contentCheck.test(textContent)) {
             return textContent;
         }
+        textContent = elements.stream().map(v -> v.getDomProperty("value")).collect(Collectors.toList());
+
+        if (contentCheck.test(textContent)) {
+            return textContent;
+        }
         textContent = elements.stream().map(v -> v.getDomAttribute("innerHTML")).collect(Collectors.toList());
+
+        if (contentCheck.test(textContent)) {
+            return textContent;
+        }
+        textContent = elements.stream().map(v -> v.getDomProperty("innerHTML")).collect(Collectors.toList());
 
         return textContent;
     };

--- a/src/main/java/dev/tidalcode/wave/commands/FindTextData.java
+++ b/src/main/java/dev/tidalcode/wave/commands/FindTextData.java
@@ -36,26 +36,34 @@ public final class FindTextData extends CommandAction implements Command<String>
     }
 
     Function<CommandContext, String> function = e -> {
-        String textContent;
-
         WebElement element = webElement.getElement(context);
-        textContent = element.getText();
 
+        String textContent = element.getText();
         if (!isNullOrEmpty(textContent)) {
             return textContent;
         }
+
+        textContent = element.getDomProperty("value");
+        if (!isNullOrEmpty(textContent)) {
+            return textContent;
+        }
+
         textContent = element.getDomAttribute("value");
-
         if (!isNullOrEmpty(textContent)) {
             return textContent;
         }
+
+        textContent = element.getDomProperty("innerHTML");
+        if (!isNullOrEmpty(textContent)) {
+            return textContent;
+        }
+
         textContent = element.getDomAttribute("innerHTML");
-
         if (!isNullOrEmpty(textContent)) {
             return textContent;
         }
-        textContent = (String) ((JavascriptExecutor) ((RemoteWebElement) element).getWrappedDriver()).executeScript("return arguments[0].innerHTML;", element);
 
+        textContent = (String) ((JavascriptExecutor) ((RemoteWebElement) element).getWrappedDriver()).executeScript("return arguments[0].innerHTML;", element);
         if (!isNullOrEmpty(textContent)) {
             return textContent;
         }

--- a/src/main/java/dev/tidalcode/wave/commands/GetAttribute.java
+++ b/src/main/java/dev/tidalcode/wave/commands/GetAttribute.java
@@ -36,7 +36,8 @@ public final class GetAttribute extends CommandAction implements Command<String>
 
     Function<CommandContext, String> function = e -> {
         WebElement element = webElement.getElement(context);
-        return element.getDomAttribute(attributeName);
+        String attribute = element.getDomAttribute(attributeName);
+        return attribute != null ? attribute : element.getDomProperty(attributeName);
     };
 
     @Override

--- a/src/main/java/dev/tidalcode/wave/commands/SetInnerHtml.java
+++ b/src/main/java/dev/tidalcode/wave/commands/SetInnerHtml.java
@@ -38,7 +38,7 @@ public final class SetInnerHtml extends CommandAction implements Command<Void> {
     }
 
     Function<CommandContext, Void> function = e -> {
-        Function<WebElement, String> expectedValue = w -> w.getDomAttribute("innerHTML");
+        Function<WebElement, String> expectedValue = w -> w.getDomProperty("innerHTML");
 
         WebElement element = webElement.getElement(context);
         ((JavascriptExecutor) ((RemoteWebElement) element).getWrappedDriver()).executeScript(String.format("arguments[0].innerHTML='%s';", inputText), element);

--- a/src/main/java/dev/tidalcode/wave/commands/SetText.java
+++ b/src/main/java/dev/tidalcode/wave/commands/SetText.java
@@ -41,20 +41,20 @@ public final class SetText extends CommandAction implements Command<Void> {
             timeCounter = new TimeCounter();
         }
 
-        Function<WebElement, String> currentInputValue = w -> w.getDomAttribute("value");
+        Function<WebElement, String> currentPropertyValue = w -> w.getDomProperty("value");
 
         WebElement element = webElement.getElement(context);
-        if (!currentInputValue.apply(element).equals(inputText)) {
+        if (!currentPropertyValue.apply(element).equals(inputText)) {
             element.sendKeys(inputText);
         }
         if (timeCounter.timeElapsed(Duration.ofSeconds(2))) {
-            int existingCharsLength = currentInputValue.apply(element).length();
+            int existingCharsLength = currentPropertyValue.apply(element).length();
             for (int i = 0; i < existingCharsLength; i++) {
                 element.sendKeys(Keys.BACK_SPACE);
             }
             element.sendKeys(inputText);
         }
-        if (!currentInputValue.apply(element).equals(inputText)) {
+        if (!currentPropertyValue.apply(element).equals(inputText)) {
             element.clear();
             throw new SetTextException("Error when tried to input text using setText method");
         }

--- a/src/main/java/dev/tidalcode/wave/commands/SetValue.java
+++ b/src/main/java/dev/tidalcode/wave/commands/SetValue.java
@@ -37,7 +37,7 @@ public final class SetValue extends CommandAction implements Command<Void> {
     }
 
     Function<CommandContext, Void> function = e -> {
-        Function<WebElement, String> expectedValue = v -> v.getDomAttribute("value");
+        Function<WebElement, String> expectedValue = v -> v.getDomProperty("value");
 
         WebElement element = webElement.getElement(context);
         ((JavascriptExecutor) ((RemoteWebElement) element).getWrappedDriver()).executeScript(String.format("arguments[0].value='%s';", inputText), element);

--- a/src/main/java/dev/tidalcode/wave/commands/TableData.java
+++ b/src/main/java/dev/tidalcode/wave/commands/TableData.java
@@ -33,7 +33,7 @@ public class TableData extends CommandAction implements Command<Table> {
 
     Function<CommandContext, Table> function = e -> {
         WebElement element = webElement.getElement(context);
-        String table = element.getDomAttribute("innerHTML");
+        String table = element.getDomProperty("innerHTML");
         return new Table("<table>" + table + "</table>");
     };
 

--- a/src/test/java/dev/tidalcode/wave/commands/SetInnerHtmlTest.java
+++ b/src/test/java/dev/tidalcode/wave/commands/SetInnerHtmlTest.java
@@ -35,7 +35,7 @@ public class SetInnerHtmlTest {
     public void textInputText() {
         String textInputLocator = "id:innerHtmlP";
         find(textInputLocator).setInnerHtml("Tidal-Wave");
-        Assert.assertEquals(find(textInputLocator).getText(), "Tidal-Wave");
+        Assert.assertEquals("Tidal-Wave", find(textInputLocator).getText());
     }
 
 }

--- a/src/test/java/dev/tidalcode/wave/commands/SetTextTest.java
+++ b/src/test/java/dev/tidalcode/wave/commands/SetTextTest.java
@@ -42,6 +42,17 @@ public class SetTextTest {
         Assert.assertEquals("", "Tidal-Wave QA Team", textAfter);
     }
 
+    @Test
+    public void inputUsingSetTextWithoutValue() {
+        String textInputLocator = "id:myText4";
+        find(textInputLocator).click().clear().setText("Extra");
+        String buttonLocator = "id:text_submit_button";
+        find(buttonLocator).click();
+
+        String textAfter = find("id:result").getText();
+        Assert.assertEquals("", "Tidal Wave QA Team Extra", textAfter);
+    }
+
     @Test(expected = RuntimeException.class)
     public void inputUsingSetTextShouldFail() {
         find("id:myText1").waitFor(6).click().clear().setText("Tidal-Wave" + Keys.TAB);

--- a/src/test/resources/components/textinput/textinput.html
+++ b/src/test/resources/components/textinput/textinput.html
@@ -15,6 +15,7 @@
     First Name: <input data-id="dataid123XXXXX" id="myText1" type="text" value="Tidal Wave"/><br>
     Middle Name: <input id="myText2" type="text" value="QA"/><br>
     Last Name: <input id="myText3" type="text" value="Team"/><br>
+    Pet: <input id="myText4" type="text"/><br>
     <button id="text_submit_button" onclick="displayValue()" type="button">Submit</button>
 </form>
 
@@ -22,7 +23,7 @@
 
 <script>
         function displayValue() {
-            var x = document.getElementById("myText1").value + " " + document.getElementById("myText2").value + " " + document.getElementById("myText3").value;
+            var x = document.getElementById("myText1").value + " " + document.getElementById("myText2").value + " " + document.getElementById("myText3").value + " " + document.getElementById("myText4").value;
             document.getElementById("result").innerHTML = x;
         }
 


### PR DESCRIPTION
latest selenium changes deprecate 'getAttribute' for new methods getDomAttribute & getDomProperty
https://www.qabash.com/getattribute-deprecation-selenium-impact/

- add extra getDomProperty check to "get"/"find" classes
- replace getDomAttribute for getDomProperty in "set" classes.

fixes #46 