### PR TITLE
chore: bump selenium version to 4.33.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.tidalcode</groupId>
     <artifactId>wave</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.9</version>
 
     <name>Tidal Automation Library</name>
     <description>Automation Code Repository</description>
@@ -54,7 +54,7 @@
         <aspectj.version>1.9.19</aspectj.version>
         <slf4j.version>2.0.6</slf4j.version>
         <jackson-lib-version>2.14.2</jackson-lib-version>
-        <selenium-version>4.31.0</selenium-version>
+        <selenium-version>4.33.0</selenium-version>
         <webdriver-manager>5.3.3</webdriver-manager>
         <tagName>@add</tagName>
         <tagNameTwo>@add</tagNameTwo>


### PR DESCRIPTION
4.33.0 release notes
https://www.selenium.dev/blog/2025/selenium-4-33-released/

-     Reverting deprecation notice for getAttribute.
-     Removing deprecated setScriptTimeout and pageLoadTimeout.
-     Removing deprecated SlowLoadableComponent constructor.
-     Removing deprecated NATIVE_EVENTS field.
-     Deprecating methods that use FirefoxBinary as well.