### PR TITLE
Chore/bump selenium to 4.35.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,16 +6,16 @@
 
     <groupId>dev.tidalcode</groupId>
     <artifactId>wave</artifactId>
-    <version>2.0.9</version>
+    <version>2.0.10</version>
 
     <name>Tidal Automation Library</name>
     <description>Automation Code Repository</description>
-    <url>http://wave.tidalcode.dev</url>
+    <url>https://wave.tidalcode.dev</url>
 
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>https://www.opensource.org/licenses/mit-license.php</url>
         </license>
     </licenses>
 
@@ -54,7 +54,7 @@
         <aspectj.version>1.9.19</aspectj.version>
         <slf4j.version>2.0.6</slf4j.version>
         <jackson-lib-version>2.14.2</jackson-lib-version>
-        <selenium-version>4.33.0</selenium-version>
+        <selenium-version>4.35.0</selenium-version>
         <webdriver-manager>5.3.3</webdriver-manager>
         <tagName>@add</tagName>
         <tagNameTwo>@add</tagNameTwo>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>dev.tidalcode</groupId>
             <artifactId>utils</artifactId>
-            <version>0.0.9</version>
+            <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>dev.tidalcode</groupId>

--- a/src/test/java/dev/tidalcode/wave/browser/OpenTest.java
+++ b/src/test/java/dev/tidalcode/wave/browser/OpenTest.java
@@ -64,9 +64,9 @@ public class OpenTest {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless");
         options.addArguments("--remote-allow-origins=*");
-        Browser.withOptions(options).open("https://google.co.nz");
+        Browser.withOptions(options).open("https://google.com");
         String currentUrl = Page.currentUrl();
-        verify("Initial URL", currentUrl).contains("google.co.nz");
+        verify("Initial URL", currentUrl).contains("google.com");
         Browser.open("https://bing.com");
         currentUrl = Page.currentUrl();
         verify("Second URL", currentUrl).contains("bing.com");

--- a/src/test/java/dev/tidalcode/wave/retry/StillNotPresentRetryTests.java
+++ b/src/test/java/dev/tidalcode/wave/retry/StillNotPresentRetryTests.java
@@ -28,7 +28,7 @@ public class StillNotPresentRetryTests {
     }
 
     @Test
-    public void retryTestIfVisible() {
+    public void retryTestIfNotPresent() {
         find("#textInput").clear().sendKeys("Retry test").clear().sendKeys("QA").retryIf(notPresent("id:newElement"), 3);
         find("id:newElement").shouldBe(present);
     }

--- a/src/test/java/dev/tidalcode/wave/retry/StillNotVisibleRetryTests.java
+++ b/src/test/java/dev/tidalcode/wave/retry/StillNotVisibleRetryTests.java
@@ -28,7 +28,7 @@ public class StillNotVisibleRetryTests {
     }
 
     @Test
-    public void retryTestIfVisible() {
+    public void retryTestIfNotVisible() {
         find("#textInput2").clear().sendKeys("Retry test").clear().sendKeys("QA").retryIf(notVisible("#buttonId"), 3);
         find("#buttonId").shouldBe(visible);
     }

--- a/src/test/java/dev/tidalcode/wave/retry/StillPresentRetryTests.java
+++ b/src/test/java/dev/tidalcode/wave/retry/StillPresentRetryTests.java
@@ -28,7 +28,7 @@ public class StillPresentRetryTests {
     }
 
     @Test
-    public void retryTestIfVisible() {
+    public void retryTestIfPresent() {
         find("#textInput").clear().sendKeys("Retry test").clear().sendKeys("QA").retryIf(stillPresent, 3);
         find("#textInput").shouldBe(notPresent);
     }

--- a/src/test/resources/configuration.properties
+++ b/src/test/resources/configuration.properties
@@ -7,8 +7,8 @@ qtest.project.id=12047
 qtest.cycle.id=CL-2
 qtest.project.folder=TCC.WBP.WDC
 updateQTest=false
-local.headless=true
-base.url=http://www.google.co.nz
+local.headless=false
+base.url=https://www.google.co.nz
 local.screensize=--window-size=1920,1080
 remote.screensize=--window-size=1920,1080
 local.timeout=6
@@ -31,4 +31,3 @@ connection.timeout=20
 read.timeout=20
 write.timeout=20
 call.timeout=20
-


### PR DESCRIPTION
chore: update selenium version, to latest (4.35.0) and tidal-code 'utils' to latest

+ small renaming of unit tests