### PR TITLE
Chore/bump selenium to 4.39.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.tidalcode</groupId>
     <artifactId>wave</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11</version>
 
     <name>Tidal Automation Library</name>
     <description>Automation Code Repository</description>
@@ -54,7 +54,7 @@
         <aspectj.version>1.9.19</aspectj.version>
         <slf4j.version>2.0.6</slf4j.version>
         <jackson-lib-version>2.14.2</jackson-lib-version>
-        <selenium-version>4.35.0</selenium-version>
+        <selenium-version>4.39.0</selenium-version>
         <webdriver-manager>5.3.3</webdriver-manager>
         <tagName>@add</tagName>
         <tagNameTwo>@add</tagNameTwo>

--- a/pom.xml
+++ b/pom.xml
@@ -45,17 +45,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
 
-        <maven-surefire-plugin>2.22.2</maven-surefire-plugin>
-        <maven-compiler-plugin>3.11.0</maven-compiler-plugin>
-        <cucumber-version>7.14.0</cucumber-version>
-        <allure-version>2.21.0</allure-version>
-        <allure.maven.version>2.12.0</allure.maven.version>
-        <allure.report.version>2.12.0</allure.report.version>
-        <aspectj.version>1.9.19</aspectj.version>
-        <slf4j.version>2.0.6</slf4j.version>
-        <jackson-lib-version>2.14.2</jackson-lib-version>
+        <maven-surefire-plugin>3.5.4</maven-surefire-plugin>
+        <maven-compiler-plugin>3.14.1</maven-compiler-plugin>
+        <cucumber-version>7.33.0</cucumber-version>
+        <allure-version>2.32.0</allure-version>
+        <allure.maven.version>2.17.0</allure.maven.version>
+        <allure.report.version>2.17.0</allure.report.version>
+        <aspectj.version>1.9.25</aspectj.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <selenium-version>4.39.0</selenium-version>
-        <webdriver-manager>5.3.3</webdriver-manager>
+        <webdriver-manager>6.3.3</webdriver-manager>
         <tagName>@add</tagName>
         <tagNameTwo>@add</tagNameTwo>
         <tagNameThree>@add</tagNameThree>
@@ -74,7 +73,7 @@
         <dependency>
             <groupId>dev.tidalcode</groupId>
             <artifactId>flow</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -102,7 +101,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>2.0.5</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -125,7 +124,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>24.0.1</version>
+            <version>26.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -135,7 +134,7 @@
         <dependency>
             <groupId>io.qameta.allure</groupId>
             <artifactId>allure-junit4</artifactId>
-            <version>2.24.0</version>
+            <version>${allure-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
main commit is to bring selenium version up to the latest. 

second commit (perhaps unnecessary) bring other dependencies up to latest versions.